### PR TITLE
Add new presenter for initial navigation stack

### DIFF
--- a/JLCoordinator.xcodeproj/project.pbxproj
+++ b/JLCoordinator.xcodeproj/project.pbxproj
@@ -363,12 +363,12 @@
 		B4961D892493983D00D19CEB /* PresenterImplementations */ = {
 			isa = PBXGroup;
 			children = (
-				B4961D8A2493983D00D19CEB /* TabPresenter */,
 				EB798D6B25ADB15100B3A4E6 /* InitialNavigationPresenter.swift */,
+				B4961D902493983D00D19CEB /* InitialPresenter.swift */,
 				B4961D8E2493983D00D19CEB /* ModalNavigationPresenter.swift */,
 				B4961D8F2493983D00D19CEB /* ModalPresenter.swift */,
-				B4961D902493983D00D19CEB /* InitialPresenter.swift */,
 				B4961D912493983D00D19CEB /* NavigationPresenter.swift */,
+				B4961D8A2493983D00D19CEB /* TabPresenter */,
 			);
 			path = PresenterImplementations;
 			sourceTree = "<group>";
@@ -421,12 +421,12 @@
 		B4961DB0249776AE00D19CEB /* PresenterTests */ = {
 			isa = PBXGroup;
 			children = (
-				B448E797249C947F002053C2 /* Helper */,
 				EB798D7025ADB18400B3A4E6 /* InitialNavigationPresenterTests.swift */,
 				B4961DB1249776CE00D19CEB /* InitialPresenterTests.swift */,
+				B4489D2F24BE079100EF394F /* ModalNavigationPresenterTests.swift */,
 				B4D1DC43249A1253008E291E /* ModalPresenterTests.swift */,
 				B448E798249C994A002053C2 /* NavigationPresenterTests.swift */,
-				B4489D2F24BE079100EF394F /* ModalNavigationPresenterTests.swift */,
+				B448E797249C947F002053C2 /* Helper */,
 			);
 			path = PresenterTests;
 			sourceTree = "<group>";

--- a/JLCoordinator.xcodeproj/project.pbxproj
+++ b/JLCoordinator.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		C9AE850924AC7D2F003C29B9 /* TabCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AE850824AC7D2F003C29B9 /* TabCoordinator.swift */; };
 		C9AE850B24AC8843003C29B9 /* ViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AE850A24AC8843003C29B9 /* ViewCoordinator.swift */; };
 		C9AE9DB524B32C4A00FA9601 /* ViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C9AE9DB424B32C4A00FA9601 /* ViewController.storyboard */; };
+		EB798D6C25ADB15100B3A4E6 /* InitialNavigationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB798D6B25ADB15100B3A4E6 /* InitialNavigationPresenter.swift */; };
+		EB798D7125ADB18400B3A4E6 /* InitialNavigationPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB798D7025ADB18400B3A4E6 /* InitialNavigationPresenterTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -150,6 +152,8 @@
 		C9AE850824AC7D2F003C29B9 /* TabCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCoordinator.swift; sourceTree = "<group>"; };
 		C9AE850A24AC8843003C29B9 /* ViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewCoordinator.swift; sourceTree = "<group>"; };
 		C9AE9DB424B32C4A00FA9601 /* ViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ViewController.storyboard; sourceTree = "<group>"; };
+		EB798D6B25ADB15100B3A4E6 /* InitialNavigationPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialNavigationPresenter.swift; sourceTree = "<group>"; };
+		EB798D7025ADB18400B3A4E6 /* InitialNavigationPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialNavigationPresenterTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -360,6 +364,7 @@
 			isa = PBXGroup;
 			children = (
 				B4961D8A2493983D00D19CEB /* TabPresenter */,
+				EB798D6B25ADB15100B3A4E6 /* InitialNavigationPresenter.swift */,
 				B4961D8E2493983D00D19CEB /* ModalNavigationPresenter.swift */,
 				B4961D8F2493983D00D19CEB /* ModalPresenter.swift */,
 				B4961D902493983D00D19CEB /* InitialPresenter.swift */,
@@ -417,6 +422,7 @@
 			isa = PBXGroup;
 			children = (
 				B448E797249C947F002053C2 /* Helper */,
+				EB798D7025ADB18400B3A4E6 /* InitialNavigationPresenterTests.swift */,
 				B4961DB1249776CE00D19CEB /* InitialPresenterTests.swift */,
 				B4D1DC43249A1253008E291E /* ModalPresenterTests.swift */,
 				B448E798249C994A002053C2 /* NavigationPresenterTests.swift */,
@@ -650,6 +656,7 @@
 				B4961D942493983D00D19CEB /* AdaptivePresentationControllerDelegateWrapper.swift in Sources */,
 				C947052724BC7A9100479ABB /* ModalPresenting.swift in Sources */,
 				C947052924BC81DD00479ABB /* InitialPresenting.swift in Sources */,
+				EB798D6C25ADB15100B3A4E6 /* InitialNavigationPresenter.swift in Sources */,
 				B4961D9F2493984500D19CEB /* Coordinator.swift in Sources */,
 				B4961D932493983D00D19CEB /* Presenter.swift in Sources */,
 				B4961D9C2493983D00D19CEB /* NavigationPresenter.swift in Sources */,
@@ -668,6 +675,7 @@
 				B448E799249C994A002053C2 /* NavigationPresenterTests.swift in Sources */,
 				B448E796249C93DF002053C2 /* MockPresenterObserving.swift in Sources */,
 				B4961DA92497530200D19CEB /* CoordinatorTests.swift in Sources */,
+				EB798D7125ADB18400B3A4E6 /* InitialNavigationPresenterTests.swift in Sources */,
 				B4961DA42493A02600D19CEB /* WeakCacheTests.swift in Sources */,
 				B4961DA72493A0B700D19CEB /* CacheableElement.swift in Sources */,
 				B4489D2E24BE047200EF394F /* MockNavigationController.swift in Sources */,

--- a/JLCoordinator/Sources/Presenter/PresenterImplementations/InitialNavigationPresenter.swift
+++ b/JLCoordinator/Sources/Presenter/PresenterImplementations/InitialNavigationPresenter.swift
@@ -1,0 +1,31 @@
+// Copyright © 2021 Jamit Labs GmbH. All rights reserved.
+
+import UIKit
+
+public class InitialNavigationPresenter: NavigationPresenter, InitialPresenting {
+    public var window: UIWindow
+
+    public init(window: UIWindow, with navigationController: UINavigationController = .init()) {
+        self.window = window
+        super.init(navigationController: navigationController)
+    }
+
+    override public func present(_ viewController: UIViewController, animated: Bool = true) {
+        // Set navigation controller as root view controller if needed.
+        if window.rootViewController !== navigationController {
+            window.rootViewController = navigationController
+            window.makeKeyAndVisible()
+        }
+
+        super.present(viewController, animated: animated)
+    }
+
+    override public func dismissRoot(animated: Bool) {
+        window.isHidden = true
+
+        navigationController.flatMap {
+            notifyObserverAboutDismiss(of: $0)
+            $0.viewControllers.forEach(notifyObserverAboutDismiss(of:))
+        }
+    }
+}

--- a/JLCoordinatorExample/Sources/SceneDelegate.swift
+++ b/JLCoordinatorExample/Sources/SceneDelegate.swift
@@ -4,7 +4,7 @@ import JLCoordinator
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    var tabCoordinator: TabCoordinator?
+    var mainCoordinator: Coordinator?
 
     func scene(
         _ scene: UIScene,
@@ -14,7 +14,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window: UIWindow = .init(windowScene: windowScene)
-        tabCoordinator = .init(presenter: InitialPresenter(window: window))
-        tabCoordinator?.start()
+
+        // Option 1: Tabs
+        mainCoordinator = TabCoordinator(presenter: InitialPresenter(window: window))
+        mainCoordinator?.start()
+
+        // Option 2: Navigation Stack
+//        mainCoordinator = ViewCoordinator(presenter: InitialNavigationPresenter(window: window))
+//        mainCoordinator?.start()
     }
 }

--- a/JLCoordinatorTests/PresenterTests/InitialNavigationPresenterTests.swift
+++ b/JLCoordinatorTests/PresenterTests/InitialNavigationPresenterTests.swift
@@ -1,0 +1,91 @@
+// Copyright © 2021 Jamit Labs GmbH. All rights reserved.
+
+import JLCoordinator
+import XCTest
+
+class InitialNavigationPresenterTests: XCTestCase {
+    func testPresentingRootViewController() throws {
+        let window: UIWindow = UIWindow()
+        let navigationController: UINavigationController = .init()
+        let presenter: InitialNavigationPresenter = .init(window: window, with: navigationController)
+        let viewController = UIViewController()
+        presenter.present(viewController)
+        XCTAssertTrue(presenter.window.isKeyWindow)
+        XCTAssertEqual(presenter.window.rootViewController, navigationController)
+        XCTAssertEqual(navigationController.topViewController, viewController)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertEqual(navigationController.viewControllers.first, viewController)
+    }
+
+    func testDismissRoot() throws {
+        let window: UIWindow = UIWindow()
+        let navigationController: UINavigationController = .init()
+        let presenter: InitialNavigationPresenter = .init(window: window, with: navigationController)
+        let viewController = UIViewController()
+        presenter.present(viewController)
+        XCTAssertTrue(presenter.window.isKeyWindow)
+        XCTAssertEqual(presenter.window.rootViewController, navigationController)
+        presenter.dismissRoot(animated: true)
+        XCTAssertTrue(window.isHidden)
+    }
+
+    func testPushViewController() throws {
+        let observer: MockPresenterObserving = .init()
+        let window: UIWindow = .init()
+        let navigationController: MockNavigationController = .init()
+        let presenter: InitialNavigationPresenter = .init(window: window, with: navigationController)
+
+        let rootViewController: UIViewController = .init()
+        presenter.present(rootViewController)
+        presenter.register(observer)
+
+        let waitExceptation = expectation(description: "Wait until push is done")
+        waitExceptation.expectedFulfillmentCount = 2
+
+        navigationController.didCallPushViewController = { viewController in
+            presenter.navigationController(navigationController, didPush: viewController)
+            waitExceptation.fulfill()
+        }
+
+        let viewControllerToPush: UIViewController = .init()
+        observer.didPresentViewControllerClosure = { _, viewController in
+            XCTAssertEqual(viewController, viewControllerToPush)
+            waitExceptation.fulfill()
+        }
+
+        presenter.present(viewControllerToPush)
+        wait(for: [waitExceptation], timeout: 1)
+    }
+
+    func testPopViewController() throws {
+        let observer: MockPresenterObserving = .init()
+        let window: UIWindow = .init()
+        let navigationController: MockNavigationController = .init()
+        let presenter: InitialNavigationPresenter = .init(window: window, with: navigationController)
+
+        let rootViewController: UIViewController = .init()
+        presenter.present(rootViewController)
+
+        let viewControllerToPop: UIViewController = .init()
+        navigationController.storedViewController = viewControllerToPop
+        presenter.register(observer)
+
+        let waitForNavigationControllerCall = expectation(description: "Wait until NavigationController is called.")
+        let waitExceptation = expectation(description: "Wait until pop is done")
+
+        navigationController.didCallPopViewController = { viewController in
+            guard let viewController = viewController else { return XCTFail("ViewController should be set!") }
+
+            presenter.navigationController(navigationController, didPop: viewController)
+            waitForNavigationControllerCall.fulfill()
+        }
+
+        observer.didDismissViewControllerClosure = { _, viewController in
+            XCTAssertEqual(viewController, viewControllerToPop)
+            waitExceptation.fulfill()
+        }
+
+        presenter.dismiss(viewControllerToPop)
+        wait(for: [waitForNavigationControllerCall, waitExceptation], timeout: 1)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Starting a child coordinator is really easy, just instantiate your child with a 
 func startNextCoordinator() {
     let child: MyChildCoordinator = .init(presenter: ModalPresenter(presentingViewController: viewController))
     add(childCoordinator: child)
-    viewCoordinator.start()
+    child.start()
 }
 ```
 
@@ -126,17 +126,17 @@ The **Coordinator** provides through implementing the `PresenterObserving` proto
 ```swift
 // If an UIViewController is dismissed this function is called
 override func presenter(_ presenter: Presenter, didDismiss viewController: UIViewController) {
-	// Do some stuff what should happend if the viewController is dismissed
-	// for example: stop()
+    // Do some stuff what should happend if the viewController is dismissed
+    // for example: stop()
 }
 
 // If an UINavigationController is dismissed this function is called
 override func presenter(_ presenter: Presenter, didDismiss navigationController: UINavigationController) {
-	// Do some stuff what should happend if the navigationController is dismissed
-	// You could check if this was the NavigationController of a specific UIViewController
-	guard myViewController.navigationController === navigationController else { return }
-	
-	stop()
+    // Do some stuff what should happend if the navigationController is dismissed
+    // You could check if this was the NavigationController of a specific UIViewController
+    guard myViewController.navigationController === navigationController else { return }
+
+    stop()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Predefined presenter implementations for the most use cases are ready to use (se
 **Predefined implementations**
 
 <details>
+<summary><b>InitialNavigationPresenter</b></summary>
+<br>
+Is used to present a NavigationController stack in a `UIWindow` (e.g. used in `AppDelegate` or `SceneDelegate`).  The first `UIViewController` will be set as `rootViewController` all further `UIViewControllers` will be pushed onto the stack.
+</details>
+
+<details>
 <summary><b>InitialPresenter</b></summary>
 <br>
 Is used to present in a `UIWindow` (e.g. used in `AppDelegate` or `SceneDelegate`)


### PR DESCRIPTION
Introduce a new navigation presenter which extends the behavior of `NavigationPresenter` by adopting `InitialPresenting` protocol. This presenter enables a setup of an initial navigation stack onto a `UIWindow` instance and can make the implementation of #4 more convenient. 

For sample use, please see `SceneDelegate.swift` in example project. 